### PR TITLE
Import polyfill and added HTMLImports.whenReady()

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ```
 <custom-element-demo>
   <template>
+    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
     <link rel="import" href="password-strength.html">
     <link rel="import" href="../vaadin-themes/valo/vaadin-text-field.html">
     <link rel="import" href="../vaadin-text-field/vaadin-password-field.html">
@@ -26,12 +27,14 @@
 <password-strength></password-strength>
 
 <script>
-  const passwordStrength = document.querySelector('password-strength')
-  setInterval(() => {
-    const random = Math.random().toString(36).substring(Math.random()*10)
-    passwordStrength.password = random
-    document.querySelector('#random-password').innerText = 'Current password: ' + random
-  }, 1000)
+  HTMLImports.whenReady(function(){
+    const passwordStrength = document.querySelector('password-strength')
+    setInterval(() => {
+      const random = Math.random().toString(36).substring(Math.random()*10)
+      passwordStrength.password = random
+      document.querySelector('#random-password').innerText = 'Current password: ' + random
+    }, 1000)
+  });
 </script>
 ```
 


### PR DESCRIPTION
The polyfill is needed for non-native polyfill browser in order to showcase the demo. Also, it takes sometimes to load the password-strength meter so adding a `HTMLImports.whenReady()` would ensure that both things start to function simultaneously.